### PR TITLE
Update: Coucbase version from v2.51 to v2.6.12 to make this repo work…

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	"homepage": "https://github.com/adpushup/NodeUtils#readme",
 	"dependencies": {
 		"bluebird": "^3.5.5",
-		"couchbase": "2.5.1",
+		"couchbase": "2.6.12",
 		"crypto-js": "^3.1.9-1",
 		"emailjs": "^1.0.12",
 		"googleapis": "^19.0.0",


### PR DESCRIPTION
Update: Coucbase version from v2.51 to v2.6.12 to make this repo work with node-v14.20.0